### PR TITLE
[Feature] add etag comparison before and after mput_data

### DIFF
--- a/UFile-CSharpSDK/Program.cs
+++ b/UFile-CSharpSDK/Program.cs
@@ -49,6 +49,18 @@ namespace UFileCSharpSDK
             }
 
             {
+                //demo for multi uploading file, check etag
+                Console.WriteLine("uploading...please wait");
+                Proxy.MultiUploader muploader = new Proxy.MultiUploader(bucket, key, originFile);
+                string local_etag = Utils.CalcEtag(originFile);
+                muploader.MInit();
+                muploader.MUpload(-1);
+                muploader.CheckEtag(local_etag, originFile);
+                muploader.MFinish();
+                Console.WriteLine(string.Format("mupload {0} {1} success", bucket, key));
+            }
+
+            {
                 //demo for multi uploading file manually
                 Console.WriteLine("uploading...please wait");
                 Proxy.MultiUploader muploader = new Proxy.MultiUploader(bucket, key, originFile);

--- a/UFile-CSharpSDK/Proxy/Proxy.cs
+++ b/UFile-CSharpSDK/Proxy/Proxy.cs
@@ -337,6 +337,31 @@ namespace UFileCSharpSDK
                 }
             }
 
+            public void CheckEtag(string local_etag_1st, string file)
+            {
+                string local_etag_2nd = Utils.CalcEtag(file);
+
+                string remote_etag = Utils.EtagByEtags(m_etags);
+
+                try
+                {
+                    if (local_etag_1st != local_etag_2nd)
+                    {
+                        throw new Exception(string.Format("local_etag_1st {0} != local_etag_2nd {1}", local_etag_1st, local_etag_2nd));
+                    }
+
+                    if (local_etag_1st != remote_etag)
+                    {
+                        throw new Exception(string.Format("local_etag {0} != remote_etag {1}", local_etag_1st, remote_etag));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.ToString());
+                    throw;
+                }
+            }
+
             public void MFinish() {
 
                 HttpWebRequest request = null;

--- a/UFile-CSharpSDK/Utils/Base64.cs
+++ b/UFile-CSharpSDK/Utils/Base64.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Text;
+
+namespace UFileCSharpSDK
+{
+    /// <summary>
+    /// Base64 编码/解码
+    /// </summary>
+    public class Base64
+    {
+        /// <summary>
+        /// 获取字符串Url安全Base64编码值
+        /// </summary>
+        /// <param name="text">源字符串</param>
+        /// <returns>已编码字符串</returns>
+        public static string UrlSafeBase64Encode(string text)
+        {
+            return UrlSafeBase64Encode(Encoding.UTF8.GetBytes(text));
+        }
+
+        /// <summary>
+        /// URL安全的base64编码
+        /// </summary>
+        /// <param name="data">需要编码的字节数据</param>
+        /// <returns></returns>
+        public static string UrlSafeBase64Encode(byte[] data)
+        {
+            return Convert.ToBase64String(data).Replace('+', '-').Replace('/', '_');
+        }
+
+        /// <summary>
+        /// bucket:key 编码
+        /// </summary>
+        /// <param name="bucket">空间名称</param>
+        /// <param name="key">文件key</param>
+        /// <returns>编码</returns>
+        public static string UrlSafeBase64Encode(string bucket, string key)
+        {
+            return UrlSafeBase64Encode(bucket + ":" + key);
+        }
+
+        /// <summary>
+        /// Base64解码
+        /// </summary>
+        /// <param name="text">待解码的字符串</param>
+        /// <returns>已解码字符串</returns>
+        public static byte[] UrlsafeBase64Decode(string text)
+        {
+            return Convert.FromBase64String(text.Replace('-', '+').Replace('_', '/'));
+        }
+    }
+}

--- a/UFile-CSharpSDK/Utils/Utils.cs
+++ b/UFile-CSharpSDK/Utils/Utils.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Security.Cryptography;
 using System.Web;
+using System.Collections.Generic;
 
 namespace UFileCSharpSDK
 {
@@ -13,6 +14,7 @@ namespace UFileCSharpSDK
 		};
 		public static int bufferLen = 32 * 1024;
 		public static int blockSize = 4 * 1024 * 1024;
+		private static int blockSha1Size = 20;
 		public static string GetMimeType(string file) {
 			return MimeTypeMap.GetMimeType (Path.GetExtension (file));
 		}
@@ -108,9 +110,121 @@ namespace UFileCSharpSDK
 			SHA1 sha = new SHA1CryptoServiceProvider ();
 			return System.Text.Encoding.Default.GetString (sha.ComputeHash (data));
 		}
+		public static byte[] GetSHA1_V2(byte[] data)
+		{
+			SHA1 sha = new SHA1CryptoServiceProvider();
+			return sha.ComputeHash(data);
+		}
 		public static string GetURLSafeBase64(string data)
 		{
 			return HttpServerUtility.UrlTokenEncode (System.Text.Encoding.Default.GetBytes(data));
+		}
+
+		public static string CalcEtag(string filePath)
+		{
+			string uetag = "";
+
+			try
+			{
+				using (FileStream stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+				{
+					long fileLength = stream.Length;
+					byte[] buffer = new byte[blockSize];
+					byte[] finalBuffer = new byte[blockSha1Size + 4];
+
+					uint blockCount = 1;
+					if (fileLength > blockSize)
+					{
+						blockCount = (uint)((fileLength % blockSize == 0) ? (fileLength / blockSize) : (fileLength / blockSize + 1));
+					}
+					byte[] bytes = BitConverter.GetBytes(blockCount);
+					if (!BitConverter.IsLittleEndian)
+					{
+						Array.Reverse(bytes);
+					}
+					Array.Copy(bytes, 0, finalBuffer, 0, bytes.Length);
+
+					if (fileLength <= blockSize)
+					{
+						int readByteCount = stream.Read(buffer, 0, blockSize);
+						byte[] readBuffer = new byte[readByteCount];
+						Array.Copy(buffer, readBuffer, readByteCount);
+
+						byte[] sha1Buffer = Utils.GetSHA1_V2(readBuffer);
+
+						Array.Copy(sha1Buffer, 0, finalBuffer, 4, sha1Buffer.Length);
+					}
+					else
+					{
+						byte[] sha1AllBuffer = new byte[blockSha1Size * blockCount];
+
+						for (int i = 0; i < blockCount; i++)
+						{
+							int readByteCount = stream.Read(buffer, 0, blockSize);
+							byte[] readBuffer = new byte[readByteCount];
+							Array.Copy(buffer, readBuffer, readByteCount);
+
+							byte[] sha1Buffer = Utils.GetSHA1_V2(readBuffer);
+							Array.Copy(sha1Buffer, 0, sha1AllBuffer, i * blockSha1Size, sha1Buffer.Length);
+						}
+
+						byte[] sha1AllBufferSha1 = Utils.GetSHA1_V2(sha1AllBuffer);
+
+						Array.Copy(sha1AllBufferSha1, 0, finalBuffer, 4, sha1AllBufferSha1.Length);
+
+					}
+					uetag = Base64.UrlSafeBase64Encode(finalBuffer);
+				}
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e.ToString());
+				throw;
+			}
+
+			return uetag;
+		}
+
+		public static string EtagByEtags(List<string> etags)
+		{
+			string uetag = "";
+
+			int blockCount = etags.Count;
+			if (blockCount <= 0)
+			{
+				throw new Exception(string.Format("etags count {0} <= 0", blockCount));
+			}
+
+			byte[] finalBuffer = new byte[blockSha1Size + 4];
+
+			byte[] bytes = BitConverter.GetBytes(blockCount);
+			if (!BitConverter.IsLittleEndian)
+			{
+				Array.Reverse(bytes);
+			}
+			Array.Copy(bytes, 0, finalBuffer, 0, bytes.Length);
+
+			if (1 == blockCount)
+			{
+				byte[] sha1Buffer = Base64.UrlsafeBase64Decode(etags[0].Replace("\"", ""));
+				Array.Copy(sha1Buffer, 0, finalBuffer, 4, sha1Buffer.Length);
+			}
+			else
+			{
+				byte[] sha1AllBuffer = new byte[blockSha1Size * blockCount];
+				for (int i = 0; i < blockCount; i++)
+				{
+					byte[] sha1Buffer = Base64.UrlsafeBase64Decode(etags[i].Replace("\"", ""));
+					Array.Copy(sha1Buffer, 0, sha1AllBuffer, i * blockSha1Size, sha1Buffer.Length);
+				}
+
+				byte[] sha1AllBufferSha1 = Utils.GetSHA1_V2(sha1AllBuffer);
+				Array.Copy(sha1AllBufferSha1, 0, finalBuffer, 4, sha1AllBufferSha1.Length);
+			}
+
+			uetag = Base64.UrlSafeBase64Encode(finalBuffer);
+
+			return uetag;
 		}
 
 	}


### PR DESCRIPTION
例子中增加在mput_data前后的etag计算和比较；
1 在mput_data前，计算本地文件etag: local_etag_1st;
2 在mput_data后，计算本地文件etag: local_etag_2nd;
3 在mput_data后，计算us3侧的整个文件的etag: remote_etag.
保证3个etag一致，才mput_finish.

测试例子：
1 单个文件的测试
1KB  / 4097KB  /  130MB / 2049MB / 6GB

2 持续测试共2250次

3 模拟错误的测试
（1）本地文件内容的修改（用修改local_etag_1st的值来模拟，有进程使用时无法修改本地文件）
![image](https://user-images.githubusercontent.com/12139322/145364093-30c8afd3-ca74-49b1-b9f4-47f816f8ae25.png)

（2）用us3侧返回的分片的etag, 计算出的整个文件的remote_etag, 和本地local_etag不相等
![image](https://user-images.githubusercontent.com/12139322/145364352-f87b9cfe-9acc-4bb7-9faf-6bcb763651af.png)

4 计算etag导致的分片上传的时间增加
![image](https://user-images.githubusercontent.com/12139322/145364585-43b6b9e4-be5e-4d2f-856c-cb5c2560c440.png)




